### PR TITLE
WIP Avoid failing Travis when nothing has changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,8 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
   include:
-    # runs linting and tests with current locked deps
-
     - stage: "Tests"
       name: "Tests"
-      install:
-        - yarn install --non-interactive
       script:
         - yarn lint:hbs
         - yarn lint:js
@@ -52,7 +48,7 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn install --no-lockfile --non-interactive
+  - yarn install --non-interactive
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO


### PR DESCRIPTION
Test need to be aware of the lock file to avoid suddenly failing tests. Lock file is kept up-to-date with Renovate.